### PR TITLE
rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+sudo: false
+version:
+    - nightly
 os:
   - linux
 env:

--- a/src/appendbuf.rs
+++ b/src/appendbuf.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Debug, Formatter};
 use std::mem;
-use std::num::Int;
 use std::sync::Arc;
 
+use primint::PrimInt;
 use raw::{Allocator, RawIobuf};
 use iobuf::{Iobuf};
 use impls::{AROIobuf};
@@ -325,7 +325,7 @@ impl<'a> AppendBuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), expected); }
   /// ```
   #[inline(always)]
-  pub fn poke_be<T: Int>(&self, pos: u32, t: T) -> Result<(), ()> {
+  pub fn poke_be<T: PrimInt>(&self, pos: u32, t: T) -> Result<(), ()> {
     self.raw.poke_be(pos, t)
   }
 
@@ -348,7 +348,7 @@ impl<'a> AppendBuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), [ 4, 5, 5, 9, 8, 7, 6 ]); }
   /// ```
   #[inline(always)]
-  pub fn poke_le<T: Int>(&self, pos: u32, t: T) -> Result<(), ()> {
+  pub fn poke_le<T: PrimInt>(&self, pos: u32, t: T) -> Result<(), ()> {
     self.raw.poke_le(pos, t)
   }
 
@@ -403,7 +403,7 @@ impl<'a> AppendBuf<'a> {
   ///                      , 0x88, 0x77 ]); }
   /// ```
   #[inline(always)]
-  pub fn fill_be<T: Int>(&mut self, t: T) -> Result<(), ()> {
+  pub fn fill_be<T: PrimInt>(&mut self, t: T) -> Result<(), ()> {
     self.raw.fill_be(t)
   }
 
@@ -431,7 +431,7 @@ impl<'a> AppendBuf<'a> {
   ///                      , 0x77, 0x88 ]); }
   /// ```
   #[inline(always)]
-  pub fn fill_le<T: Int>(&mut self, t: T) -> Result<(), ()> {
+  pub fn fill_le<T: PrimInt>(&mut self, t: T) -> Result<(), ()> {
     self.raw.fill_le(t)
   }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,9 +2,9 @@ use core::nonzero::NonZero;
 
 use std::fmt::{self, Debug, Formatter};
 use std::mem;
-use std::num::Int;
 use std::sync::Arc;
 
+use primint::PrimInt;
 use raw::{Allocator, RawIobuf};
 use iobuf::Iobuf;
 
@@ -639,7 +639,7 @@ impl<'a> RWIobuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), expected); }
   /// ```
   #[inline(always)]
-  pub fn poke_be<T: Int>(&self, pos: u32, t: T) -> Result<(), ()> { self.raw.poke_be(pos, t) }
+  pub fn poke_be<T: PrimInt>(&self, pos: u32, t: T) -> Result<(), ()> { self.raw.poke_be(pos, t) }
 
   /// Writes a little-endian primitive at a given offset from the beginning of
   /// the window.
@@ -660,7 +660,7 @@ impl<'a> RWIobuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), [ 4, 5, 5, 9, 8, 7, 6 ]); }
   /// ```
   #[inline(always)]
-  pub fn poke_le<T: Int>(&self, pos: u32, t: T) -> Result<(), ()> { self.raw.poke_le(pos, t) }
+  pub fn poke_le<T: PrimInt>(&self, pos: u32, t: T) -> Result<(), ()> { self.raw.poke_le(pos, t) }
 
   /// Writes bytes from the supplied buffer, starting from the front of the
   /// window. Either the entire buffer is copied, or an error is returned
@@ -711,7 +711,7 @@ impl<'a> RWIobuf<'a> {
   ///                                          , 0x88, 0x77 ]); }
   /// ```
   #[inline(always)]
-  pub fn fill_be<T: Int>(&mut self, t: T) -> Result<(), ()> { self.raw.fill_be(t) }
+  pub fn fill_be<T: PrimInt>(&mut self, t: T) -> Result<(), ()> { self.raw.fill_be(t) }
 
   /// Writes a little-endian primitive into the beginning of the window.
   ///
@@ -737,7 +737,7 @@ impl<'a> RWIobuf<'a> {
   ///                                          , 0x77, 0x88 ]); }
   /// ```
   #[inline(always)]
-  pub fn fill_le<T: Int>(&mut self, t: T) -> Result<(), ()> { self.raw.fill_le(t) }
+  pub fn fill_le<T: PrimInt>(&mut self, t: T) -> Result<(), ()> { self.raw.fill_le(t) }
 
   /// Writes the bytes at a given offset from the beginning of the window, into
   /// the supplied buffer. It is undefined behavior to write outside the iobuf
@@ -789,7 +789,7 @@ impl<'a> RWIobuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), [ 3, 5, 5, 6, 7, 8, 9 ]); }
   /// ```
   #[inline(always)]
-  pub unsafe fn unsafe_poke_be<T: Int>(&self, pos: u32, t: T) { self.raw.unsafe_poke_be(pos, t) }
+  pub unsafe fn unsafe_poke_be<T: PrimInt>(&self, pos: u32, t: T) { self.raw.unsafe_poke_be(pos, t) }
 
   /// Writes a little-endian primitive at a given offset from the beginning of
   /// the window. It is undefined behavior to write outside the iobuf window.
@@ -812,7 +812,7 @@ impl<'a> RWIobuf<'a> {
   /// unsafe { assert_eq!(b.as_window_slice(), [ 4, 5, 5, 9, 8, 7, 6 ]); }
   /// ```
   #[inline(always)]
-  pub unsafe fn unsafe_poke_le<T: Int>(&self, pos: u32, t: T) { self.raw.unsafe_poke_le(pos, t) }
+  pub unsafe fn unsafe_poke_le<T: PrimInt>(&self, pos: u32, t: T) { self.raw.unsafe_poke_le(pos, t) }
 
   /// Writes bytes from the supplied buffer, starting from the front of the
   /// window. It is undefined behavior to write outside the iobuf window.
@@ -868,7 +868,7 @@ impl<'a> RWIobuf<'a> {
   ///                                          , 0x88, 0x77 ]); }
   /// ```
   #[inline(always)]
-  pub unsafe fn unsafe_fill_be<T: Int>(&mut self, t: T) { self.raw.unsafe_fill_be(t) }
+  pub unsafe fn unsafe_fill_be<T: PrimInt>(&mut self, t: T) { self.raw.unsafe_fill_be(t) }
 
   /// Writes a little-endian primitive into the beginning of the window. It is
   /// undefined behavior to write outside the iobuf window.
@@ -897,7 +897,7 @@ impl<'a> RWIobuf<'a> {
   ///                                          , 0x77, 0x88 ]); }
   /// ```
   #[inline(always)]
-  pub unsafe fn unsafe_fill_le<T: Int>(&mut self, t: T) { self.raw.unsafe_fill_le(t) }
+  pub unsafe fn unsafe_fill_le<T: PrimInt>(&mut self, t: T) { self.raw.unsafe_fill_le(t) }
 }
 
 impl AROIobuf {
@@ -1108,16 +1108,16 @@ impl<'a> Iobuf for ROIobuf<'a> {
   #[inline(always)]
   fn peek(&self, pos: u32, dst: &mut [u8]) -> Result<(), ()> { self.raw.peek(pos, dst) }
   #[inline(always)]
-  fn peek_be<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
+  fn peek_be<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
   #[inline(always)]
-  fn peek_le<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
+  fn peek_le<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
 
   #[inline(always)]
   fn consume(&mut self, dst: &mut [u8]) -> Result<(), ()> { self.raw.consume(dst) }
   #[inline(always)]
-  fn consume_be<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
+  fn consume_be<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
   #[inline(always)]
-  fn consume_le<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
+  fn consume_le<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
 
   #[inline(always)]
   fn check_range(&self, pos: u32, len: u32) -> Result<(), ()> { self.raw.check_range_u32(pos, len) }
@@ -1134,16 +1134,16 @@ impl<'a> Iobuf for ROIobuf<'a> {
   #[inline(always)]
   unsafe fn unsafe_peek(&self, pos: u32, dst: &mut [u8]) { self.raw.unsafe_peek(pos, dst) }
   #[inline(always)]
-  unsafe fn unsafe_peek_be<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
+  unsafe fn unsafe_peek_be<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
   #[inline(always)]
-  unsafe fn unsafe_peek_le<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
+  unsafe fn unsafe_peek_le<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
 
   #[inline(always)]
   unsafe fn unsafe_consume(&mut self, dst: &mut [u8]) { self.raw.unsafe_consume(dst) }
   #[inline(always)]
-  unsafe fn unsafe_consume_be<T: Int>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
+  unsafe fn unsafe_consume_be<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
   #[inline(always)]
-  unsafe fn unsafe_consume_le<T: Int>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
+  unsafe fn unsafe_consume_le<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
 
   #[inline(always)]
   unsafe fn as_raw<'b>(&'b self) -> &RawIobuf<'b> { mem::transmute(&self.raw) }
@@ -1316,16 +1316,16 @@ impl Iobuf for AROIobuf {
   #[inline(always)]
   fn peek(&self, pos: u32, dst: &mut [u8]) -> Result<(), ()> { self.raw.peek(pos, dst) }
   #[inline(always)]
-  fn peek_be<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
+  fn peek_be<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
   #[inline(always)]
-  fn peek_le<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
+  fn peek_le<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
 
   #[inline(always)]
   fn consume(&mut self, dst: &mut [u8]) -> Result<(), ()> { self.raw.consume(dst) }
   #[inline(always)]
-  fn consume_be<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
+  fn consume_be<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
   #[inline(always)]
-  fn consume_le<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
+  fn consume_le<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
 
   #[inline(always)]
   fn check_range(&self, pos: u32, len: u32) -> Result<(), ()> { self.raw.check_range_u32(pos, len) }
@@ -1342,16 +1342,16 @@ impl Iobuf for AROIobuf {
   #[inline(always)]
   unsafe fn unsafe_peek(&self, pos: u32, dst: &mut [u8]) { self.raw.unsafe_peek(pos, dst) }
   #[inline(always)]
-  unsafe fn unsafe_peek_be<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
+  unsafe fn unsafe_peek_be<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
   #[inline(always)]
-  unsafe fn unsafe_peek_le<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
+  unsafe fn unsafe_peek_le<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
 
   #[inline(always)]
   unsafe fn unsafe_consume(&mut self, dst: &mut [u8]) { self.raw.unsafe_consume(dst) }
   #[inline(always)]
-  unsafe fn unsafe_consume_be<T: Int>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
+  unsafe fn unsafe_consume_be<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
   #[inline(always)]
-  unsafe fn unsafe_consume_le<T: Int>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
+  unsafe fn unsafe_consume_le<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
 
   #[inline(always)]
   unsafe fn as_raw<'b>(&'b self) -> &RawIobuf<'b> { mem::transmute(&self.raw) }
@@ -1524,16 +1524,16 @@ impl<'a> Iobuf for RWIobuf<'a> {
   #[inline(always)]
   fn peek(&self, pos: u32, dst: &mut [u8]) -> Result<(), ()> { self.raw.peek(pos, dst) }
   #[inline(always)]
-  fn peek_be<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
+  fn peek_be<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_be(pos) }
   #[inline(always)]
-  fn peek_le<T: Int>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
+  fn peek_le<T: PrimInt>(&self, pos: u32) -> Result<T, ()> { self.raw.peek_le(pos) }
 
   #[inline(always)]
   fn consume(&mut self, dst: &mut [u8]) -> Result<(), ()> { self.raw.consume(dst) }
   #[inline(always)]
-  fn consume_be<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
+  fn consume_be<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_be::<T>() }
   #[inline(always)]
-  fn consume_le<T: Int>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
+  fn consume_le<T: PrimInt>(&mut self) -> Result<T, ()> { self.raw.consume_le::<T>() }
 
   #[inline(always)]
   fn check_range(&self, pos: u32, len: u32) -> Result<(), ()> { self.raw.check_range_u32(pos, len) }
@@ -1550,16 +1550,16 @@ impl<'a> Iobuf for RWIobuf<'a> {
   #[inline(always)]
   unsafe fn unsafe_peek(&self, pos: u32, dst: &mut [u8]) { self.raw.unsafe_peek(pos, dst) }
   #[inline(always)]
-  unsafe fn unsafe_peek_be<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
+  unsafe fn unsafe_peek_be<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_be(pos) }
   #[inline(always)]
-  unsafe fn unsafe_peek_le<T: Int>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
+  unsafe fn unsafe_peek_le<T: PrimInt>(&self, pos: u32) -> T { self.raw.unsafe_peek_le(pos) }
 
   #[inline(always)]
   unsafe fn unsafe_consume(&mut self, dst: &mut [u8]) { self.raw.unsafe_consume(dst) }
   #[inline(always)]
-  unsafe fn unsafe_consume_be<T: Int>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
+  unsafe fn unsafe_consume_be<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_be::<T>() }
   #[inline(always)]
-  unsafe fn unsafe_consume_le<T: Int>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
+  unsafe fn unsafe_consume_le<T: PrimInt>(&mut self) -> T { self.raw.unsafe_consume_le::<T>() }
 
   #[inline(always)]
   unsafe fn as_raw<'b>(&'b self) -> &'b RawIobuf<'b> { mem::transmute(&self.raw) }

--- a/src/iobuf.rs
+++ b/src/iobuf.rs
@@ -1,9 +1,9 @@
 use core::nonzero::NonZero;
 
 use std::fmt::Debug;
-use std::num::Int;
 use std::sync::Arc;
 
+use primint::PrimInt;
 use raw::{Allocator, RawIobuf};
 use impls::{AROIobuf, RWIobuf, UniqueIobuf};
 
@@ -778,7 +778,7 @@ pub trait Iobuf: Clone + Debug {
   /// assert_eq!(b.peek_be(1), Ok(0x0304u16));
   /// assert_eq!(b.peek_be::<u16>(2), Err(()));
   /// ```
-  fn peek_be<T: Int>(&self, pos: u32) -> Result<T, ()>;
+  fn peek_be<T: PrimInt>(&self, pos: u32) -> Result<T, ()>;
 
   /// Reads a little-endian primitive at a given offset from the beginning of
   /// the window.
@@ -797,7 +797,7 @@ pub trait Iobuf: Clone + Debug {
   /// assert_eq!(b.peek_le(1), Ok(0x0403u16));
   /// assert_eq!(b.peek_le::<u16>(2), Err(()));
   /// ```
-  fn peek_le<T: Int>(&self, pos: u32) -> Result<T, ()>;
+  fn peek_le<T: PrimInt>(&self, pos: u32) -> Result<T, ()>;
 
   /// Reads bytes, starting from the front of the window, into the supplied
   /// buffer. Either the entire buffer is filled, or an error is returned
@@ -842,7 +842,7 @@ pub trait Iobuf: Clone + Debug {
   /// assert_eq!(b.consume_be::<u16>(), Err(()));
   /// assert_eq!(b.consume_be(), Ok(0x04u8));
   /// ```
-  fn consume_be<T: Int>(&mut self) -> Result<T, ()>;
+  fn consume_be<T: PrimInt>(&mut self) -> Result<T, ()>;
 
   /// Reads a little-endian primitive from the beginning of the window.
   ///
@@ -863,7 +863,7 @@ pub trait Iobuf: Clone + Debug {
   /// assert_eq!(b.consume_le::<u16>(), Err(()));
   /// assert_eq!(b.consume_le(), Ok(0x04u8));
   /// ```
-  fn consume_le<T: Int>(&mut self) -> Result<T, ()>;
+  fn consume_le<T: PrimInt>(&mut self) -> Result<T, ()>;
 
   /// Returns an `Err(())` if the `len` bytes, starting at `pos`, are not all
   /// in the window. To be used with the `try!` macro.
@@ -988,7 +988,7 @@ pub trait Iobuf: Clone + Debug {
   ///   assert_eq!(z, 0x0102 + 0x03040506);
   /// }
   /// ```
-  unsafe fn unsafe_peek_be<T: Int>(&self, pos: u32) -> T;
+  unsafe fn unsafe_peek_be<T: PrimInt>(&self, pos: u32) -> T;
 
   /// Reads a little-endian primitive at a given offset from the beginning of
   /// the window. It is undefined behavior to read outside the iobuf window.
@@ -1009,7 +1009,7 @@ pub trait Iobuf: Clone + Debug {
   ///   assert_eq!(z, 0x0201 + 0x06050403);
   /// }
   /// ```
-  unsafe fn unsafe_peek_le<T: Int>(&self, pos: u32) -> T;
+  unsafe fn unsafe_peek_le<T: PrimInt>(&self, pos: u32) -> T;
 
   /// Reads bytes, starting from the front of the window, into the supplied
   /// buffer. After the bytes have been read, the window will be moved to no
@@ -1039,7 +1039,7 @@ pub trait Iobuf: Clone + Debug {
   ///   assert_eq!(b.unsafe_consume_be::<u8>(), 0x04u8);
   /// }
   /// ```
-  unsafe fn unsafe_consume_be<T: Int>(&mut self) -> T;
+  unsafe fn unsafe_consume_be<T: PrimInt>(&mut self) -> T;
 
   /// Reads a little-endian primitive at the beginning of the window.
   ///
@@ -1062,7 +1062,7 @@ pub trait Iobuf: Clone + Debug {
   ///   assert_eq!(b.unsafe_consume_le::<u8>(), 0x04u8);
   /// }
   /// ```
-  unsafe fn unsafe_consume_le<T: Int>(&mut self) -> T;
+  unsafe fn unsafe_consume_le<T: PrimInt>(&mut self) -> T;
 
   /// For internal use only.
   unsafe fn as_raw<'b>(&'b self) -> &RawIobuf<'b>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,4 @@ mod impls;
 mod ringbuf;
 mod bufspan;
 mod appendbuf;
+mod primint;

--- a/src/primint.rs
+++ b/src/primint.rs
@@ -1,0 +1,36 @@
+/// A trait for converting the endianness of primitive integers.
+pub trait PrimInt: Sized + Copy {
+    /// Convert an integer from big endian to the target's endianness.
+    ///
+    /// On big endian this is a no-op. On little endian the bytes are swapped.
+    fn from_be(Self) -> Self;
+
+    /// Convert an integer from little endian to the target's endianness.
+    ///
+    /// On little endian this is a no-op. On big endian the bytes are swapped.
+    fn from_le(Self) -> Self;
+
+    /// Convert `self` into little endian from the target's endianness.
+    ///
+    /// On little endian this is a no-op. On big endian the bytes are swapped.
+    fn to_le(self) -> Self;
+
+    /// Convert `self` into big endian from the target's endianness.
+    ///
+    /// On big endian this is a no-op. On little endian the bytes are swapped.
+    fn to_be(self) -> Self;
+}
+
+macro_rules! primint_impl {
+    ($($T:ty)*) => ($(
+        impl PrimInt for $T {
+            fn from_be(x: Self) -> Self { <$T>::from_be(x) }
+            fn from_le(x: Self) -> Self { <$T>::from_le(x) }
+            fn to_le(self) -> Self { <$T>::to_le(self) }
+            fn to_be(self) -> Self { <$T>::to_be(self) }
+        }
+    )*)
+}
+
+primint_impl! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
+


### PR DESCRIPTION
Adjust for the deprecation of std::num::Integer and the reordering of arguments
for memory copying operations.