### PR TITLE
Make iobuf compile with Rust Nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,21 +37,17 @@
 //! Fun tidbit: Data allocated by `Iobuf` is guaranteed to be aligned to 16 bytes.
 //! This may be abused to write efficient SIMD data processing code.
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 #![feature(filling_drop)]
 #![feature(plugin)]
 #![feature(unsafe_no_drop_flag)]
 #![feature(core_intrinsics)]
-#![feature(iter_order)]
 #![feature(nonzero)]
 #![feature(raw)]
 #![feature(heap_api)]
 #![feature(iter_arith)]
-#![feature(num_bits_bytes)]
 
 #![feature(alloc)]
-#![feature(core)]
 
 #![cfg_attr(test, feature(test))]
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -25,6 +25,8 @@ const TARGET_WORD_SIZE: usize = 32;
 /// efficient SIMD code on Iobufs.
 const DATA_ALIGNMENT: usize = 16;
 
+const U32_BITS: usize = 32;
+
 /// The biggest Iobuf supported, to allow us to have a small RawIobuf struct.
 /// By limiting the buffer sizes, we can bring the struct down from 40 bytes to
 /// 24 bytes -- a 40% reduction. This frees up precious cache and registers for
@@ -32,7 +34,7 @@ const DATA_ALIGNMENT: usize = 16;
 const MAX_BUFFER_LEN: usize = i32::MAX as usize - ALLOCATION_HEADER_SIZE;
 
 /// The bitmask to get the "is the buffer owned" bit.
-const OWNED_MASK: u32 = 1 << (u32::BITS - 1);
+const OWNED_MASK: u32 = 1 << (U32_BITS - 1);
 
 /// Used to provide custom memory to Iobufs, instead of just using the heap.
 pub trait Allocator: Sync + Send {
@@ -43,7 +45,7 @@ pub trait Allocator: Sync + Send {
   fn deallocate(&self, ptr: NonZero<*mut u8>, len: usize, align: usize);
 }
 
-struct AllocationHeader {
+pub struct AllocationHeader {
   allocator: Option<NonZero<*mut ()>>,
   allocation_length: usize,
   refcount: usize,


### PR DESCRIPTION
Hi,

I was very interested in your project and I tried to compile it using Rust nightly (2016-03-29).  Unfortunately I got a few warnings and errors, so I forked your repo and "fixed" them.  I quoted that because I am not sure if my fixes are the correct thing to do.  

Just in case they are, perhaps you are interested, so here is what I did:

- Introduced a constant for u32 bit count because that is removed in nightly
- Made the AllocationHeader struct public because it is used in a public trait
- Removed some, I think, unnecessary entries in lib.rs (I at least got warnings from these)

Kevin