### PR TITLE
Fixes to new NonZero API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 #![feature(nonzero)]
 #![feature(heap_api)]
 #![feature(alloc)]
+#![feature(unique)]
 
 #![cfg_attr(test, feature(test))]
 


### PR DESCRIPTION
Hey! 
Trying to get RxRust to compile, I ran into some issue because of type `core::nonzero::NonZero<*mut ()>` cannot be dereferenced (anymore I guess)
These are proposed fixes to the new nightly API